### PR TITLE
Handle routes in controllers

### DIFF
--- a/classes/FaviconController.php
+++ b/classes/FaviconController.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Initbiz\SeoStorm\Classes;
+
+use File;
+use Resizer;
+use Cms\Classes\Controller;
+use Initbiz\SeoStorm\Models\Settings;
+
+class FaviconController
+{
+    public function index()
+    {
+        $settings = Settings::instance();
+
+        if (!$settings->favicon_enabled) {
+            $controller = new Controller();
+            $controller->setStatusCode(404);
+
+            return $controller->run('/404');;
+        }
+
+        $finalPath = $inputPath = storage_path('app/media' . $settings->favicon);
+
+        if ($settings->favicon_16) {
+
+            $destinationPath = storage_path('app/initbiz/seostorm/favicon/' . dirname($settings->favicon) . '/');
+            $finalPath = $outputPath = $destinationPath . basename($settings->favicon);
+
+            if (!file_exists($outputPath)) {
+                if (
+                    !File::makeDirectory($destinationPath, 0777, true, true) &&
+                    !File::isDirectory($destinationPath)
+                ) {
+                    trigger_error(error_get_last(), E_USER_WARNING);
+                }
+
+                Resizer::open($inputPath)->resize(16, 16)->save($outputPath);
+                $finalPath = $outputPath;
+            }
+        }
+
+        return response()->file($finalPath, [
+            'Content-Type' => 'image/x-icon',
+        ]);
+    }
+}

--- a/classes/RobotsController.php
+++ b/classes/RobotsController.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Initbiz\SeoStorm\Classes;
+
+class RobotsController
+{
+    public function index()
+    {
+        return Robots::generate();
+    }
+}

--- a/classes/SitemapController.php
+++ b/classes/SitemapController.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Initbiz\SeoStorm\Classes;
+
+use Response;
+use Cms\Classes\Controller;
+use Initbiz\SeoStorm\Models\Settings;
+
+class SitemapController
+{
+    public function index()
+    {
+        $sitemap = new Sitemap();
+
+        if (!Settings::get('enable_sitemap')) {
+            $controller = new Controller();
+            $controller->setStatusCode(404);
+
+            return $controller->run('/404');
+        } else {
+            return Response::make($sitemap->generate())->header('Content-Type', 'application/xml');
+        }
+    }
+}

--- a/routes.php
+++ b/routes.php
@@ -2,63 +2,13 @@
 
 namespace Initbiz\SeoStorm;
 
-use App;
-use File;
 use Route;
-use Resizer;
-use Response;
-use Cms\Classes\Controller;
-use Initbiz\SeoStorm\Classes\Robots;
-use Initbiz\SeoStorm\Classes\Sitemap;
-use Initbiz\SeoStorm\Models\Settings;
+use Initbiz\SeoStorm\Classes\RobotsController;
+use Initbiz\SeoStorm\Classes\SitemapController;
+use Initbiz\SeoStorm\Classes\FaviconController;
 
-Route::get('robots.txt', function () {
-    return Robots::response();
-});
+Route::get('robots.txt', [RobotsController::class, 'index']);
 
-Route::get('sitemap.xml', function () {
-    $sitemap = new Sitemap();
-    if (!Settings::get('enable_sitemap')) {
-        $controller = new Controller();
-        $controller->setStatusCode(404);
+Route::get('sitemap.xml', [SitemapController::class, 'index']);
 
-        return $controller->run('/404');;
-    } else {
-        return Response::make($sitemap->generate())->header('Content-Type', 'application/xml');
-    }
-});
-
-Route::get('favicon.ico', function () {
-    $settings = Settings::instance();
-
-    if (!$settings->favicon_enabled) {
-        $controller = new Controller();
-        $controller->setStatusCode(404);
-
-        return $controller->run('/404');;
-    }
-
-    $finalPath = $inputPath = storage_path('app/media' . $settings->favicon);
-
-    if ($settings->favicon_16) {
-
-        $destinationPath = storage_path('app/initbiz/seostorm/favicon/' . dirname($settings->favicon) . '/');
-        $finalPath = $outputPath = $destinationPath . basename($settings->favicon);
-
-        if (!file_exists($outputPath)) {
-            if (
-                !File::makeDirectory($destinationPath, 0777, true, true) &&
-                !File::isDirectory($destinationPath)
-            ) {
-                trigger_error(error_get_last(), E_USER_WARNING);
-            }
-
-            Resizer::open($inputPath)->resize(16, 16)->save($outputPath);
-            $finalPath = $outputPath;
-        }
-    }
-
-    return response()->file($finalPath, [
-        'Content-Type' => 'image/x-icon',
-    ]);
-});
+Route::get('favicon.ico', [FaviconController::class, 'index']);


### PR DESCRIPTION
Create controllers to handle the custom routes to prevent the `Unable to prepare route [route] for serialization. Uses Closure.` error and allow the `route:cache` command to work.

Fixes #51 