### PR TITLE
Sitemap links to localized urls

### DIFF
--- a/classes/Sitemap.php
+++ b/classes/Sitemap.php
@@ -43,7 +43,6 @@ class  Sitemap
         $translationsEnabled = (PluginManager::instance())->hasPlugin('RainLab.Translate');
         if ($translationsEnabled) {
             $locales = \RainLab\Translate\Models\Locale::listEnabled();
-            unset($locales[\RainLab\Translate\Models\Locale::getDefault()->code]); // remove the default so we can skip checks later
             $router = new \October\Rain\Router\Router;
         }
 
@@ -144,9 +143,9 @@ class  Sitemap
                 $sitemapItem->changefreq = $viewBag->property('changefreq');
 
                 if ($translationsEnabled) {
-                    $localeUrls = $viewBag->property('localeUrl');
+                    $localeUrls = $viewBag->property('localeUrl', []);
                     foreach ($locales as $locale => $label) {
-                        $url = is_array($localeUrls) && array_key_exists($locale, $localeUrls) ? $localeUrls[$locale] : $staticPage->url;
+                        $url = array_key_exists($locale, $localeUrls) ? $localeUrls[$locale] : $staticPage->url;
                         $sitemapItem->links[] = [
                             'rel' => 'alternate',
                             'hreflang' => $locale,
@@ -233,7 +232,7 @@ class  Sitemap
 
         if (is_array($links) && count($links) > 0) {
             foreach ($links as $link) {
-                $linkEl = $xml->createElementNS('http://www.w3.org/1999/xhtml', 'xhtml:link');
+                $linkEl = $xml->createElement('xhtml:link');
                 foreach ($link as $attr => $attrValue) {
                     $linkEl->setAttribute($attr, $attrValue);
                 }

--- a/classes/Sitemap.php
+++ b/classes/Sitemap.php
@@ -43,8 +43,13 @@ class  Sitemap
         // initialise locale related vars, if available
         $translationsEnabled = (PluginManager::instance())->hasPlugin('RainLab.Translate');
         if ($translationsEnabled) {
-            $locales = \RainLab\Translate\Models\Locale::listEnabled();
-            $defaultLocale = \RainLab\Translate\Models\Locale::getDefault()->code;
+            if(class_exists('RainLab\Translate\Models\Locale')) {
+                $localeClass = '\RainLab\Translate\Models\Locale';
+            } elseif(class_exists('RainLab\Translate\Classes\Locale')) {
+                $localeClass = '\RainLab\Translate\Classes\Locale';
+            }
+            $locales = $localeClass::listEnabled();
+            $defaultLocale = ($localeClass::getDefault())->code;
             $router = new \October\Rain\Router\Router;
         }
 

--- a/classes/Sitemap.php
+++ b/classes/Sitemap.php
@@ -32,6 +32,7 @@ class  Sitemap
 
     public function generate($pages = [])
     {
+
         if (empty($pages)) {
             // get all pages of the current theme
             $pages = Page::listInTheme(Theme::getEditTheme());
@@ -58,7 +59,7 @@ class  Sitemap
 
             if($translationsEnabled) {
                 $page->rewriteTranslatablePageUrl($defaultLocale);
-                $loc = url($router->urlFromPattern(sprintf("/%s%s", $locale, $page->url)));
+                $loc = url($router->urlFromPattern(sprintf("/%s%s", $defaultLocale, $page->url)));
             } else {
                 $loc = $page->url;
             }
@@ -71,10 +72,11 @@ class  Sitemap
 
             if ($translationsEnabled) {
                 foreach ($locales as $locale => $label) {
+                    $page->rewriteTranslatablePageUrl($locale);
                     $sitemapItem->links[] = [
                         'rel' => 'alternate',
                         'hreflang' => $locale,
-                        'href' => url($router->urlFromPattern(sprintf("/%s%s", $locale, $page->url)))
+                        'href' => url($router->urlFromPattern(sprintf("/%s%s/", $locale, $page->url)))
                     ];
                 }
             }
@@ -141,7 +143,11 @@ class  Sitemap
                 }
 
                 $sitemapItem = new SitemapItem();
-                $sitemapItem->loc = url($router->urlFromPattern(sprintf("/%s%s", $defaultLocale, $staticPage->url)));
+                if($translationsEnabled) {
+                    $sitemapItem->loc = url($router->urlFromPattern(sprintf("/%s%s", $defaultLocale, $staticPage->url)));
+                } else {
+                    $sitemapItem->loc = url($staticPage->url);
+                }
                 $sitemapItem->lastmod = $viewBag->property('lastmod') ?: $staticPage->mtime;
                 $sitemapItem->priority = $viewBag->property('priority');
                 $sitemapItem->changefreq = $viewBag->property('changefreq');

--- a/classes/SitemapItem.php
+++ b/classes/SitemapItem.php
@@ -11,4 +11,6 @@ class SitemapItem
     public $priority;
 
     public $changefreq;
+
+    public $links = [];
 }


### PR DESCRIPTION
This is a starting point for sitemaps with links to localized pages, like describe in issue #34 .

We have it in production for some weeks, mainly for sites with static pages from Rainlabs Pages plugin.
I've just tested it with some CMS pages and it seems to work after some fixes and produces the following URL items:

```
<?xml version="1.0" encoding="UTF-8"?>
<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xhtml="http://www.w3.org/1999/xhtml" xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd">
    <url>
        <loc>https://example.com/de/impressum</loc>
        <lastmod>2022-09-20T14:16:10+00:00</lastmod>
        <changefreq>always</changefreq>
        <priority>0.1</priority>
        <xhtml:link rel="alternate" hreflang="de" href="https://example.com/de/impressum" />
        <xhtml:link rel="alternate" hreflang="fr" href="https://example.com/fr/impressum" />
    </url>
    <url>
        <loc>https://example.com/de</loc>
        <lastmod>2022-10-14T11:28:16+00:00</lastmod>
        <changefreq>always</changefreq>
        <priority>1.0</priority>
        <xhtml:link rel="alternate" hreflang="de" href="https://example.com/de" />
        <xhtml:link rel="alternate" hreflang="fr" href="https://example.com/fr" />
    </url>
    <url>
        <loc>https://example.com/de/informationen</loc>
        <lastmod>2022-10-14T09:04:03+00:00</lastmod>
        <changefreq>always</changefreq>
        <priority>0.9</priority>
        <xhtml:link rel="alternate" hreflang="de" href="https://example.com/de/informationen" />
        <xhtml:link rel="alternate" hreflang="fr" href="https://example.com/fr/informations-generales" />
    </url>
    <url>
        <loc>https://example.com/de/programm</loc>
        <lastmod>2022-10-11T06:36:08+00:00</lastmod>
        <changefreq>always</changefreq>
        <priority>0.9</priority>
        <xhtml:link rel="alternate" hreflang="de" href="https://example.com/de/programm" />
        <xhtml:link rel="alternate" hreflang="fr" href="https://example.com/fr/programme" />
    </url>
</urlset>
```

Some caveats:
- I did not test it with any kind of models. If anyone is willing to provide some sample data, I'll gladly take a stab at it.
- I've mainly used from sites with static pages, not many CMS pages where included
- I only used it with OctoberCMS V2 so far. I've tested the plugin on a V3 docker version, but not extensivly. It seems to work and produces the expected results, but it certainly needs some more testing.

I hope you'll find it useful as a starting point and I'm happy to work further on it if anyone has any feedback or input.