### PR TITLE
Make canonical always present, but set a default value if not defined

### DIFF
--- a/components/seo/default.htm
+++ b/components/seo/default.htm
@@ -6,9 +6,7 @@
 <meta name="description" content="{{ include(template_from_string(__SELF__.getDescription())) }}" />
 {% endif %}
 {% set canonical = include(template_from_string(__SELF__.getSeoAttribute('canonical_url'))) %}
-{% if canonical %}
-<link rel="canonical" href="{{ __SELF__.getCanonicalUrl(canonical) }}">
-{% endif %}
+<link rel="canonical" href="{{ __SELF__.getCanonicalUrl(canonical)|default(''|page) }}">
 {% endif %}
 {% if settings.enable_robots_meta %}
 {% set advancedRobots = include(template_from_string(__SELF__.getSeoAttribute('robot_advanced'))) %}


### PR DESCRIPTION
Hello,

Lot of SEO software mark the absence of canonical URL as a bad point in term of SEO. It seems to be better to always define one, even if it's the same url than the page you are actually viewing.

Knowing that, I would change a little the SEO Storm component, removing the condition that check the canonical variable, but define a default value to the actual page when it's not present.

Best regards,