### PR TITLE
Fixing tests run from project

### DIFF
--- a/eventhandlers/SitemapHandler.php
+++ b/eventhandlers/SitemapHandler.php
@@ -82,6 +82,12 @@ class SitemapHandler
         $this->registerEventsInTheme($currentTheme);
     }
 
+    /**
+     * Register listeners on afterDelete and afterSave events on all CMS pages in the theme
+     *
+     * @param Theme $theme
+     * @return void
+     */
     public function registerEventsInTheme(Theme $theme): void
     {
         if (in_array($theme->getDirName(), self::$themesWithEvents)) {

--- a/eventhandlers/SitemapHandler.php
+++ b/eventhandlers/SitemapHandler.php
@@ -92,7 +92,7 @@ class SitemapHandler
      */
     public function registerEventsInTheme(Theme $theme): void
     {
-        if (in_array($theme->getDirName(), self::$themesWithEvents)) {
+        if (in_array($theme->getDirName(), self::$themesWithEvents, true)) {
             return;
         }
 

--- a/tests/classes/StormedTestCase.php
+++ b/tests/classes/StormedTestCase.php
@@ -8,10 +8,10 @@ use Config;
 use Schema;
 use PluginTestCase;
 use Cms\Classes\Theme;
-use Initbiz\SeoStorm\EventHandlers\SitemapHandler;
 use System\Classes\MarkupManager;
 use System\Classes\PluginManager;
 use Initbiz\SeoStorm\Models\Settings;
+use Initbiz\SeoStorm\EventHandlers\SitemapHandler;
 
 abstract class StormedTestCase extends PluginTestCase
 {

--- a/tests/classes/StormedTestCase.php
+++ b/tests/classes/StormedTestCase.php
@@ -6,8 +6,10 @@ use Config;
 use Schema;
 use PluginTestCase;
 use Cms\Classes\Theme;
+use Initbiz\SeoStorm\EventHandlers\SitemapHandler;
 use System\Classes\MarkupManager;
 use System\Classes\PluginManager;
+use Initbiz\SeoStorm\Models\Settings;
 
 abstract class StormedTestCase extends PluginTestCase
 {
@@ -22,6 +24,8 @@ abstract class StormedTestCase extends PluginTestCase
         Config::set('system.themes_path', $themesPath);
         app()->useThemesPath($themesPath);
         Theme::setActiveTheme('test');
+        SitemapHandler::clearCache();
+        Settings::clearInternalCache();
 
         $markupManager = MarkupManager::instance();
         $markupManager->listFunctions();

--- a/tests/unit/eventhandlers/SitemapHandlerTest.php
+++ b/tests/unit/eventhandlers/SitemapHandlerTest.php
@@ -31,7 +31,9 @@ class SitemapHandlerTest extends StormedTestCase
     {
         Queue::fake(ScanPageForMediaItemsJob::class);
 
+        Config::set('system.themes_path', 'plugins/initbiz/seostorm/tests/themes');
         Theme::setActiveTheme('test');
+
         $theme = Theme::load('test');
         $page = Page::load($theme, 'with-fake-model-category');
 

--- a/tests/unit/eventhandlers/SitemapHandlerTest.php
+++ b/tests/unit/eventhandlers/SitemapHandlerTest.php
@@ -6,6 +6,7 @@ use Queue;
 use Config;
 use Cms\Classes\Page;
 use Cms\Classes\Theme;
+use Initbiz\SeoStorm\EventHandlers\SitemapHandler;
 use System\Models\SiteDefinition;
 use Initbiz\Seostorm\Models\SitemapItem;
 use Initbiz\SeoStorm\Jobs\ScanPageForMediaItemsJob;
@@ -20,10 +21,6 @@ class SitemapHandlerTest extends StormedTestCase
     {
         parent::setUp();
 
-        $themesPath = plugins_path('initbiz/seostorm/tests/themes');
-        Config::set('system.themes_path', $themesPath);
-        app()->useThemesPath($themesPath);
-
         PagesGenerator::resetCache();
     }
 
@@ -31,11 +28,10 @@ class SitemapHandlerTest extends StormedTestCase
     {
         Queue::fake(ScanPageForMediaItemsJob::class);
 
-        Config::set('system.themes_path', 'plugins/initbiz/seostorm/tests/themes');
-        Theme::setActiveTheme('test');
-
         $theme = Theme::load('test');
         $page = Page::load($theme, 'with-fake-model-category');
+        $sitemapHandler = new SitemapHandler();
+        $sitemapHandler->registerEventsInTheme($theme);
 
         $category = new FakeStormedCategory();
         $category->name = 'Category';
@@ -76,7 +72,6 @@ class SitemapHandlerTest extends StormedTestCase
             url('/') . '/model/category/model-2',
         ];
 
-        dd($expectedArray, $sitemapItems);
         $this->assertEquals($expectedArray, $sitemapItems);
     }
 }

--- a/tests/unit/eventhandlers/SitemapHandlerTest.php
+++ b/tests/unit/eventhandlers/SitemapHandlerTest.php
@@ -31,6 +31,7 @@ class SitemapHandlerTest extends StormedTestCase
     {
         Queue::fake(ScanPageForMediaItemsJob::class);
 
+        Theme::setActiveTheme('test');
         $theme = Theme::load('test');
         $page = Page::load($theme, 'with-fake-model-category');
 
@@ -73,6 +74,7 @@ class SitemapHandlerTest extends StormedTestCase
             url('/') . '/model/category/model-2',
         ];
 
+        dd($expectedArray, $sitemapItems);
         $this->assertEquals($expectedArray, $sitemapItems);
     }
 }

--- a/tests/unit/eventhandlers/SitemapHandlerTest.php
+++ b/tests/unit/eventhandlers/SitemapHandlerTest.php
@@ -5,12 +5,11 @@ declare(strict_types=1);
 namespace Initbiz\SeoStorm\Tests\Unit\Classes;
 
 use Queue;
-use Config;
 use Cms\Classes\Page;
 use Cms\Classes\Theme;
-use Initbiz\SeoStorm\EventHandlers\SitemapHandler;
 use System\Models\SiteDefinition;
 use Initbiz\Seostorm\Models\SitemapItem;
+use Initbiz\SeoStorm\EventHandlers\SitemapHandler;
 use Initbiz\SeoStorm\Jobs\ScanPageForMediaItemsJob;
 use Initbiz\SeoStorm\Tests\Classes\StormedTestCase;
 use Initbiz\SeoStorm\Tests\Classes\FakeStormedModel;

--- a/tests/unit/models/SitemapItemTest.php
+++ b/tests/unit/models/SitemapItemTest.php
@@ -17,6 +17,7 @@ use Initbiz\SeoStorm\Tests\Classes\StormedTestCase;
 use Initbiz\SeoStorm\Tests\Classes\FakeStormedModel;
 use Initbiz\SeoStorm\Sitemap\Generators\PagesGenerator;
 use Initbiz\SeoStorm\Tests\Classes\FakeModelDetailsComponent;
+use Initbiz\SeoStorm\EventHandlers\SitemapHandler;
 
 class SitemapItemTest extends StormedTestCase
 {
@@ -127,6 +128,9 @@ class SitemapItemTest extends StormedTestCase
         $settings->set('enable_images_sitemap', true);
         $settings->set('enable_videos_sitemap', true);
         Theme::setActiveTheme('test');
+        $theme = Theme::load('test');
+        $sitemapHandler = new SitemapHandler();
+        $sitemapHandler->registerEventsInTheme($theme);
 
         Queue::fake([ScanPageForMediaItemsJob::class]);
 

--- a/tests/unit/models/SitemapItemTest.php
+++ b/tests/unit/models/SitemapItemTest.php
@@ -12,13 +12,13 @@ use System\Models\SiteDefinition;
 use Initbiz\SeoStorm\Models\Settings;
 use Initbiz\Seostorm\Models\SitemapItem;
 use Initbiz\Seostorm\Models\SitemapMedia;
+use Initbiz\SeoStorm\EventHandlers\SitemapHandler;
 use Initbiz\SeoStorm\Jobs\ScanPageForMediaItemsJob;
 use Initbiz\SeoStorm\Jobs\UniqueQueueJobDispatcher;
 use Initbiz\SeoStorm\Tests\Classes\StormedTestCase;
 use Initbiz\SeoStorm\Tests\Classes\FakeStormedModel;
 use Initbiz\SeoStorm\Sitemap\Generators\PagesGenerator;
 use Initbiz\SeoStorm\Tests\Classes\FakeModelDetailsComponent;
-use Initbiz\SeoStorm\EventHandlers\SitemapHandler;
 
 class SitemapItemTest extends StormedTestCase
 {

--- a/tests/unit/sitemap/generators/PagesGeneratorTest.php
+++ b/tests/unit/sitemap/generators/PagesGeneratorTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Initbiz\SeoStorm\Tests\Unit\Classes;
 
 use Queue;
-use Config;
 use Carbon\Carbon;
 use Cms\Classes\Page;
 use Cms\Classes\Theme;

--- a/tests/unit/sitemap/generators/PagesGeneratorTest.php
+++ b/tests/unit/sitemap/generators/PagesGeneratorTest.php
@@ -23,10 +23,6 @@ class PagesGeneratorTest extends StormedTestCase
     {
         parent::setUp();
 
-        $themesPath = plugins_path('initbiz/seostorm/tests/themes');
-        Config::set('system.themes_path', $themesPath);
-        app()->useThemesPath($themesPath);
-
         PagesGenerator::resetCache();
         SitemapItem::truncate();
     }

--- a/tests/unit/sitemap/generators/PagesGeneratorTest.php
+++ b/tests/unit/sitemap/generators/PagesGeneratorTest.php
@@ -472,7 +472,7 @@ class PagesGeneratorTest extends StormedTestCase
         $staticPage = $pagesGenerator->getEnabledStaticPages($theme)[0];
         $pagesGenerator->refreshForStaticPage($staticPage);
 
-        $staticPage = StaticPage::query()->find('test-static');
+        $staticPage = StaticPage::on('test')->find('test-static');
         $staticPage->viewBag['enabled_in_sitemap'] = "0";
         $pagesGenerator->refreshForStaticPage($staticPage);
 

--- a/updates/version.yaml
+++ b/updates/version.yaml
@@ -98,3 +98,5 @@
     - "Fix problem with RainLab translate"
 5.3.7:
     - "Fix translating meta fields"
+5.3.8:
+    - "Fix running tests from project"


### PR DESCRIPTION
I needed to move registering events on the pages to a separate method and run it manually in tests because of project's theme being pulled at the beginning. After we registered events on the project's theme pages, it didn't work on the plugins testing theme.