### PR TITLE
Add Tailor support to SEO Storm

### DIFF
--- a/blueprints/meta_fields.yaml
+++ b/blueprints/meta_fields.yaml
@@ -1,0 +1,86 @@
+uuid: 51d73b12-6510-44e8-aaaf-d861eb46ab82
+name: SEO Meta Fields
+type: mixin
+handle: Initbiz\SeoStorm\MetaFields
+
+fields:
+    meta_title:
+        label: initbiz.seostorm::lang.form.general.meta_title_label
+        type: text
+        span: full
+        tab: initbiz.seostorm::lang.form.general.tab_meta
+        trans: true
+        attributes:
+            data-counter: 1
+            data-min: 30
+            data-max: 60
+            data-seo: title
+
+    ignore_global_title_position:
+        label: initbiz.seostorm::lang.form.general.ignore_global_title_position_label
+        comment: initbiz.seostorm::lang.form.general.ignore_global_title_position_comment
+        type: checkbox
+        span: full
+        column: false
+        scope: false
+        tab: initbiz.seostorm::lang.form.general.tab_meta
+        trans: true
+
+    meta_description:
+        label: initbiz.seostorm::lang.form.general.meta_description_label
+        type: textarea
+        size: tiny
+        span: full
+        tab: initbiz.seostorm::lang.form.general.tab_meta
+        cssClass: char-counter
+        trans: true
+        attributes:
+            data-counter: 1
+            data-min: 100
+            data-max: 160
+            data-seo: description
+
+    canonical_url:
+        label: initbiz.seostorm::lang.form.general.canonical_url_label
+        commentAbove: initbiz.seostorm::lang.form.general.canonical_url_comment
+        tab: initbiz.seostorm::lang.form.general.tab_meta
+        type: text
+        span: full
+        trans: true
+
+    robot_index:
+        column: false
+        label: initbiz.seostorm::lang.form.general.robot_index_label
+        commentAbove: initbiz.seostorm::lang.form.general.robot_index_comment
+        tab: initbiz.seostorm::lang.form.general.tab_meta
+        type: balloon-selector
+        trans: true
+        scope: false
+        options:
+            index: Index
+            noindex: Noindex
+            '': initbiz.seostorm::lang.form.general.robot_empty
+        span: left
+        default: index
+
+    robot_follow:
+        scope: false
+        label: initbiz.seostorm::lang.form.general.robot_follow_label
+        commentAbove: initbiz.seostorm::lang.form.general.robot_follow_comment
+        tab: initbiz.seostorm::lang.form.general.tab_meta
+        type: balloon-selector
+        trans: true
+        options:
+            follow: Follow
+            nofollow: Nofollow
+            '': initbiz.seostorm::lang.form.general.robot_empty
+        span: right
+        default: follow
+
+    robot_advanced:
+        scope: false
+        label: initbiz.seostorm::lang.form.general.robot_advanced_label
+        commentAbove: initbiz.seostorm::lang.form.general.robot_advanced_comment
+        tab: initbiz.seostorm::lang.form.general.tab_meta
+        span: left
+        column: false

--- a/blueprints/og_fields.yaml
+++ b/blueprints/og_fields.yaml
@@ -1,0 +1,86 @@
+uuid: 4789825d-4b31-407c-a687-05b5c1c8b32d
+name: SEO OG Fields
+type: mixin
+handle: Initbiz\SeoStorm\OgFields
+
+fields:
+
+    og_title:
+        label: initbiz.seostorm::lang.form.general.og_title_label
+        commentAbove: initbiz.seostorm::lang.form.general.og_title_comment
+        tab: initbiz.seostorm::lang.form.general.tab_open_graph
+        placeholder: initbiz.seostorm::lang.form.general.og_title_placeholder
+        span: auto
+        type: text
+        trans: true
+        column: false
+        scope: false
+
+    og_description:
+        label: initbiz.seostorm::lang.form.general.og_description_label
+        commentAbove: initbiz.seostorm::lang.form.general.og_description_comment
+        tab: initbiz.seostorm::lang.form.general.tab_open_graph
+        placeholder: initbiz.seostorm::lang.form.general.og_description_placeholder
+        type: textarea
+        size: tiny
+        column: false
+        scope: false
+        span: auto
+        trans: true
+    og_url:
+        scope: false
+        column: false
+        label: initbiz.seostorm::lang.form.general.og_url_label
+        tab: initbiz.seostorm::lang.form.general.tab_open_graph
+        span: auto
+        type: text
+        trans: true
+    og_type:
+        scope: false
+        column: false
+        label: initbiz.seostorm::lang.form.general.og_type_label
+        tab: initbiz.seostorm::lang.form.general.tab_open_graph
+        placeholder: initbiz.seostorm::lang.form.general.og_type_placeholder
+        span: auto
+
+    og_card:
+        scope: false
+        label: initbiz.seostorm::lang.form.general.og_card_label
+        tab: initbiz.seostorm::lang.form.general.tab_open_graph
+        type: dropdown
+        default: summary_large_image
+        span: left
+        column: false
+        options:
+            summary_large_image: summary_large_image
+            summary: summary
+            app: app
+            player: player
+
+    og_image:
+        column: false
+        label: initbiz.seostorm::lang.form.general.og_image_label
+        commentAbove: initbiz.seostorm::lang.form.general.og_image_comment
+        type: mediafinder
+        mode: image
+        tab: initbiz.seostorm::lang.form.general.tab_open_graph
+        span: auto
+
+    og_ref_image:
+        label: initbiz.seostorm::lang.form.general.og_ref_image_label
+        commentAbove: initbiz.seostorm::lang.form.general.og_ref_image_comment
+        tab: initbiz.seostorm::lang.form.general.tab_open_graph
+        placeholder: initbiz.seostorm::lang.form.general.og_ref_image_placeholder
+        span: auto
+    twitter_site:
+        label: initbiz.seostorm::lang.form.settings.twitter_site
+        type: text
+        span: auto
+        comment: initbiz.seostorm::lang.form.settings.twitter_site_comment
+        tab: initbiz.seostorm::lang.form.general.tab_open_graph
+    twitter_creator:
+        label: initbiz.seostorm::lang.form.settings.twitter_creator
+        type: text
+        span: auto
+        comment: initbiz.seostorm::lang.form.settings.twitter_creator_comment
+        tab: initbiz.seostorm::lang.form.general.tab_open_graph

--- a/blueprints/schema_fields.yaml
+++ b/blueprints/schema_fields.yaml
@@ -1,0 +1,131 @@
+uuid: 7c25272a-0626-4d70-8214-c1f6967435c8
+name: SEO Schema Fields
+type: mixin
+handle: Initbiz\SeoStorm\SchemaFields
+
+fields:
+    schema_type:
+        label: initbiz.seostorm::lang.form.general.schema_type_label
+        commentAbove: initbiz.seostorm::lang.form.general.schema_type_comment
+        type: dropdown
+        span: full
+        tab: initbiz.seostorm::lang.form.general.tab_schema
+        trans: true
+        column: false
+        scope: false
+        options:
+            '': 'Select type'
+            'WebPage': 'Web Page'
+            'Article': 'Article'
+            'Book': 'Book'
+            'BreadcrumbList': 'Breadcrumb List'
+            'ItemList': 'Item List'
+            'Course': 'Course'
+            'SpecialAnnouncement': 'Covid 19'
+            'Dataset': 'Dataset'
+            'Quiz': 'Quiz'
+            'EmployerAggregateRating': 'Employer Aggregate Rating'
+            'Occupation': 'Occupation'
+            'Event': 'Event'
+            'ClaimReview': 'ClaimReview'
+            'FAQPage': 'FAQ Page'
+            'HowTo': 'How To'
+            'ImageObject': 'Image Object'
+            'JobPosting': 'Job Posting'
+            'LearningResource': 'Learning Resource'
+            'VideoObject': 'Video Object'
+            'LocalBusiness': 'Local Business'
+            'Organization': 'Logo(Organization)'
+            'MathSolver': 'Math Solver'
+            'Movie': 'Movie'
+            'Product': 'Product'
+            'Review': 'Review'
+            'Offer': 'Offer'
+            'QAPage': 'QA Page'
+            'Recipe': 'Recipe'
+            'AggregateRating': 'Aggregate Rating'
+            'SoftwareApplication': 'Software Application'
+            'CreativeWork': 'Creative Work'
+            'Clip': 'Clip'
+            'BroadcastEvent': 'Broadcast Event'
+
+    schema_image:
+        label: initbiz.seostorm::lang.form.general.schema_image_label
+        commentAbove: initbiz.seostorm::lang.form.general.schema_image_comment
+        type: mediafinder
+        mode: image
+        tab: initbiz.seostorm::lang.form.general.tab_schema
+        span: auto
+        scope: false
+
+
+    schema_ref_image:
+        label: initbiz.seostorm::lang.form.general.schema_ref_image_label
+        commentAbove: initbiz.seostorm::lang.form.general.schema_ref_image_comment
+        tab: initbiz.seostorm::lang.form.general.tab_schema
+        placeholder: initbiz.seostorm::lang.form.general.og_ref_image_placeholder
+        scope: false
+        span: auto
+        column: false
+
+    schema_main_entity:
+        label: initbiz.seostorm::lang.form.general.schema_main_entity_label
+        commentAbove: initbiz.seostorm::lang.form.general.schema_main_entity_comment
+        tab: initbiz.seostorm::lang.form.general.tab_schema
+        type: checkbox
+        span: auto
+        scope: false
+        column: false
+
+    schema_main_entity_type:
+        label: initbiz.seostorm::lang.form.general.schema_main_entity_type_label
+        commentAbove: initbiz.seostorm::lang.form.general.schema_main_entity_type_comment
+        tab: initbiz.seostorm::lang.form.general.tab_schema
+        type: dropdown
+        span: left
+        scope: false
+        column: false
+        options:
+            '': 'Select type'
+            'WebPage': 'Web Page'
+            'Article': 'Article'
+            'Book': 'Book'
+            'BreadcrumbList': 'Breadcrumb List'
+            'ItemList': 'Item List'
+            'Course': 'Course'
+            'SpecialAnnouncement': 'Covid 19'
+            'Dataset': 'Dataset'
+            'Quiz': 'Quiz'
+            'EmployerAggregateRating': 'Employer Aggregate Rating'
+            'Occupation': 'Occupation'
+            'Event': 'Event'
+            'ClaimReview': 'ClaimReview'
+            'FAQPage': 'FAQ Page'
+            'HowTo': 'How To'
+            'ImageObject': 'Image Object'
+            'JobPosting': 'Job Posting'
+            'LearningResource': 'Learning Resource'
+            'VideoObject': 'Video Object'
+            'LocalBusiness': 'Local Business'
+            'Organization': 'Logo(Organization)'
+            'MathSolver': 'Math Solver'
+            'Movie': 'Movie'
+            'Product': 'Product'
+            'Review': 'Review'
+            'Offer': 'Offer'
+            'QAPage': 'QA Page'
+            'Recipe': 'Recipe'
+            'AggregateRating': 'Aggregate Rating'
+            'SoftwareApplication': 'Software Application'
+            'CreativeWork': 'Creative Work'
+            'Clip': 'Clip'
+            'BroadcastEvent': 'Broadcast Event'
+
+    schema_main_entity_id:
+        label: initbiz.seostorm::lang.form.general.schema_main_entity_id_label
+        commentAbove: initbiz.seostorm::lang.form.general.schema_main_entity_id_comment
+        tab: initbiz.seostorm::lang.form.general.tab_schema
+        type: text
+        span: auto
+        column: false
+        scope: false

--- a/blueprints/sitemap_fields.yaml
+++ b/blueprints/sitemap_fields.yaml
@@ -1,0 +1,122 @@
+uuid: fbd491f9-1a25-4d92-927d-4435078bf269
+name: SEO Sitemap Fields
+type: mixin
+handle: Initbiz\SeoStorm\SitemapFields
+
+fields:
+
+    enabled_in_sitemap:
+        label: initbiz.seostorm::lang.form.general.enabled_in_sitemap_label
+        commentAbove: initbiz.seostorm::lang.form.general.enabled_in_sitemap_comment
+        tab: initbiz.seostorm::lang.form.general.tab_sitemap
+        type: checkbox
+        default: true
+        span: left
+        trans: true
+        scope: false
+
+
+    use_updated_at:
+        label: initbiz.seostorm::lang.form.general.use_updated_at_label
+        commentAbove: initbiz.seostorm::lang.form.general.use_updated_at_comment
+        tab: initbiz.seostorm::lang.form.general.tab_sitemap
+        commentHtml: true
+        span: left
+        scope: false
+        type: checkbox
+        default: true
+        trigger:
+            action: show
+            field: enabled_in_sitemap
+            condition: checked
+
+    lastmod:
+        label: initbiz.seostorm::lang.form.general.lastmod_label
+        commentAbove: initbiz.seostorm::lang.form.general.lastmod_comment
+        scope: false
+        tab: initbiz.seostorm::lang.form.general.tab_sitemap
+        type: datepicker
+        mode: datetime
+        span: right
+        trigger:
+            action: show
+            field: enabled_in_sitemap
+            condition: checked
+
+    changefreq:
+        label: initbiz.seostorm::lang.form.general.changefreq_label
+        scope: false
+        commentAbove: initbiz.seostorm::lang.form.general.changefreq_comment
+        tab: initbiz.seostorm::lang.form.general.tab_sitemap
+        type: dropdown
+        options:
+            always: always
+            hourly: hourly
+            daily: daily
+            weekly: weekly
+            monthly: monthly
+            yearly: yearly
+            never: never
+        span: left
+        trigger:
+            action: show
+            field: enabled_in_sitemap
+            condition: checked
+
+    priority:
+        label: initbiz.seostorm::lang.form.general.priority_label
+        commentAbove: initbiz.seostorm::lang.form.general.priority_comment
+        tab: initbiz.seostorm::lang.form.general.tab_sitemap
+        type: dropdown
+        options:
+            '0.1': '0.1'
+            '0.2': '0.2'
+            '0.3': '0.3'
+            '0.4': '0.4'
+            '0.5': '0.5'
+            '0.6': '0.6'
+            '0.7': '0.7'
+            '0.8': '0.8'
+            '0.9': '0.9'
+            '1.0': '1.0'
+        span: left
+        trigger:
+            action: show
+            field: enabled_in_sitemap
+            condition: checked
+
+    model_class:
+        scope: false
+        column: false
+        label: initbiz.seostorm::lang.form.general.model_class_label
+        commentAbove: initbiz.seostorm::lang.form.general.model_class_comment
+        tab: initbiz.seostorm::lang.form.general.tab_sitemap
+        placeholder: initbiz.seostorm::lang.form.general.model_class_placeholder
+        type: text
+        span: left
+        trigger:
+            action: show
+            field: enabled_in_sitemap
+            condition: checked
+
+    model_scope:
+        label: initbiz.seostorm::lang.form.general.model_scope_label
+        commentAbove: initbiz.seostorm::lang.form.general.model_scope_comment
+        tab: initbiz.seostorm::lang.form.general.tab_sitemap
+        placeholder: initbiz.seostorm::lang.form.general.model_scope_placeholder
+        type: text
+        span: right
+        trigger:
+            action: show
+            field: enabled_in_sitemap
+            condition: checked
+
+    model_params:
+        label: initbiz.seostorm::lang.form.general.model_params_label
+        commentAbove: initbiz.seostorm::lang.form.general.model_params_comment
+        placeholder: initbiz.seostorm::lang.form.general.model_params_placeholder
+        tab: initbiz.seostorm::lang.form.general.tab_sitemap
+        trigger:
+            action: show
+            field: enabled_in_sitemap
+            condition: checked

--- a/config/sitemapfields.yaml
+++ b/config/sitemapfields.yaml
@@ -73,6 +73,11 @@ priority:
         field: enabled_in_sitemap
         condition: checked
 
+is_tailor_class:
+    label: Is tailor?
+    type: checkbox
+    tab: initbiz.seostorm::lang.form.general.tab_sitemap
+    description: If checked the sitemap generator will query the tailor model, add the model class for example Blog\Post below instead of the full model path.
 model_class:
     label: initbiz.seostorm::lang.form.general.model_class_label
     commentAbove: initbiz.seostorm::lang.form.general.model_class_comment
@@ -84,6 +89,7 @@ model_class:
         action: show
         field: enabled_in_sitemap
         condition: checked
+
 
 model_scope:
     label: initbiz.seostorm::lang.form.general.model_scope_label


### PR DESCRIPTION
This pull request adds native support for OctoberCMS Tailor models to the SEO Storm plugin, enabling seamless use with Tailor-based content.

What’s included

Tailor blueprints
Introduces the required Tailor blueprints to define SEO Storm models as Tailor entries.

Backend option for Tailor models
Adds a backend setting to mark an SEO model as Tailor-based. This allows the plugin to distinguish between Tailor-powered models and classic Eloquent models.

Sitemap generator support for Tailor entries
When a model is marked as Tailor-based, the sitemap generator uses Tailor entries as the data source and generates URLs directly from Tailor content.

Rationale

OctoberCMS is increasingly centered around Tailor as its primary content system. This change ensures SEO Storm is compatible with modern Tailor-based projects, allowing SEO data management and sitemap generation for Tailor content without custom workarounds.

Backward compatibility

Existing non-Tailor models continue to function unchanged. The new behavior is enabled only when the “Use Tailor model” option is selected.
